### PR TITLE
Fix for URLs with anchor links with spaces

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -96,7 +96,7 @@
 				var tab = tabs[0];
 				
 				if(tab.url !== undefined) {
-					owner.currentUrl = tab.url;	
+					owner.currentUrl = tab.url.split("#")[0];
 				}	
 				
 				owner.currentTabId = tab.id;


### PR DESCRIPTION
Page purge breaks with URLs with spaces in anchor links, like:

http://www.wholesalesolar.com/brands/schneider#Inverter Accessories

Fix just strips the anchor links altogether and keeps the bare URL.
